### PR TITLE
Add tacita to Prototype Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ An extension of [mockK](https://mockk.io/) that allows for programmatic mocking 
 
 ## Prototype Projects
 
-### [tacita](https://episode6.github.io/tacita): [![Maven Central](https://img.shields.io/maven-central/v/com.episode6.tacita/tacita.svg?style=flat-square)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.episode6.tacita%22)
-
-A Kotlin Multiplatform library that downloads podcast episodes and losslessly removes dynamically-injected ads by diffing two copies of the same episode.
-
 ### [typed2! (for android)](https://episode6.github.io/typed2): [![Maven Central](https://img.shields.io/maven-central/v/com.episode6.typed2/core.svg?style=flat-square)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.episode6.typed2%22)
 
 A kotlin re-imagining of typed! (for android). Provides an extensible system to define type-safe, null-safe and optionally async-aware keys for Android's obnoxious key-value stores (i.e. SharedPreferences, Bundles, Intents, SavedStateHandles, NavArguments, etc).
+
+### [tacita](https://episode6.github.io/tacita): [![Maven Central](https://img.shields.io/maven-central/v/com.episode6.tacita/tacita.svg?style=flat-square)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.episode6.tacita%22)
+
+A Kotlin Multiplatform library that downloads podcast episodes and losslessly removes dynamically-injected ads by diffing two copies of the same episode.
 
 ## Legacy Java Projects
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A kotlin re-imagining of typed! (for android). Provides an extensible system to 
 
 ### [tacita](https://episode6.github.io/tacita): [![Maven Central](https://img.shields.io/maven-central/v/com.episode6.tacita/tacita.svg?style=flat-square)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.episode6.tacita%22)
 
-A Kotlin Multiplatform library that downloads podcast episodes and losslessly removes dynamically-injected ads by diffing two copies of the same episode.
+A vibecoded Kotlin Multiplatform library that downloads podcast episodes and losslessly removes dynamically-injected ads by diffing two copies of the same episode.
 
 ## Legacy Java Projects
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ An extension of [mockK](https://mockk.io/) that allows for programmatic mocking 
 
 ## Prototype Projects
 
+### [tacita](https://episode6.github.io/tacita): [![Maven Central](https://img.shields.io/maven-central/v/com.episode6.tacita/tacita.svg?style=flat-square)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.episode6.tacita%22)
+
+A Kotlin Multiplatform library that downloads podcast episodes and losslessly removes dynamically-injected ads by diffing two copies of the same episode.
+
 ### [typed2! (for android)](https://episode6.github.io/typed2): [![Maven Central](https://img.shields.io/maven-central/v/com.episode6.typed2/core.svg?style=flat-square)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.episode6.typed2%22)
 
 A kotlin re-imagining of typed! (for android). Provides an extensible system to define type-safe, null-safe and optionally async-aware keys for Android's obnoxious key-value stores (i.e. SharedPreferences, Bundles, Intents, SavedStateHandles, NavArguments, etc).


### PR DESCRIPTION
Adds a mention of [tacita](https://episode6.github.io/tacita) (v0.0.1, just released) to the Prototype Projects section, matching the existing entry format with a Maven Central badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDUGEGZBwCaM7uUY8SbfUe