### PR TITLE
Add a Collins project icon

### DIFF
--- a/project-icon.svg
+++ b/project-icon.svg
@@ -1,0 +1,8 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <!-- episode6.github.io: dark tile, a page/document with a folded corner, and the e6 mark (from ~/dev/project-icon.svg) inside it -->
+  <rect x="8" y="8" width="112" height="112" rx="26" fill="#20242c" stroke="#454b58" stroke-width="2"/>
+  <path d="M 34,18 H 76 L 100,42 V 104 Q 100,110 94,110 H 34 Q 28,110 28,104 V 24 Q 28,18 34,18 Z" fill="#EDE9E1"/>
+  <path d="M 76,18 V 36 Q 76,42 82,42 H 100 Z" fill="#B9B3A8"/>
+  <path transform="translate(33,65) scale(0.40)" fill="#262320" d="M 10,0 H 46 Q 56,0 56,10 V 22 Q 56,28 48,28 H 19 Q 16,28 16,25 V 21 Q 16,18 19,18 H 38 Q 40,18 40,16 V 14 Q 40,12 38,12 H 16 Q 14,12 14,14 V 31 Q 14,33 16,33 H 50 Q 56,33 56,38 Q 56,46 48,46 H 10 Q 0,46 0,36 V 10 Q 0,0 10,0 Z"/>
+  <path transform="translate(57,42) scale(0.40)" fill="#FF6600" fill-rule="evenodd" d="M 12,0 H 80 Q 92,0 92,12 V 20 Q 92,30 82,30 H 79 Q 73,30 73,27 V 24 Q 73,21 70,21 H 22 Q 19,21 19,24 V 43 Q 19,46 22,46 H 80 Q 92,46 92,58 V 93 Q 92,105 80,105 H 12 Q 0,105 0,93 V 12 Q 0,0 12,0 Z M 25,62 H 67 Q 73,62 73,68 V 82 Q 73,88 67,88 H 25 Q 19,88 19,82 V 68 Q 19,62 25,62 Z"/>
+</svg>


### PR DESCRIPTION
Adds a `project-icon.svg` to the repo root. Collins picks this up automatically and shows it in the sidebar in place of the generic folder icon for this project.

The icon is a dark rounded tile holding a page with a folded corner (this repo is the episode6 website), with the e6 wordmark laid over it — grey `e`, orange `6`, matching the mark used elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3Kyggvh5hC8tCn67nwmee